### PR TITLE
修复容器内的 jenkins 用户无法加入 docker 用户组的问题。

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ USER root
 
 COPY start-agent.sh /usr/local/bin/start.sh
 RUN chmod 755 /usr/local/bin/start.sh
-ENTRYPOINT [ "/usr/local/bin/start.sh" ]
+ENTRYPOINT [ "/bin/bash", "/usr/local/bin/start.sh" ]
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ FROM jenkins/inbound-agent:${BASE_TAG}
 
 USER root
 
-RUN groupadd -g 987 docker && usermod -aG docker jenkins
+COPY start-agent.sh /usr/local/bin/start.sh
+ENTRYPOINT [ "/usr/local/bin/start.sh" ]
 
 RUN apt-get update && apt-get install -y \
     ca-certificates \
@@ -16,5 +17,4 @@ RUN apt-get update && apt-get install -y \
     apt-get update && apt-get install -y docker-ce-cli docker-buildx-plugin docker-compose-plugin && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-USER jenkins
-
+ENV DOCKER_HOST=unix:///var/run/docker.sock

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,7 @@ FROM jenkins/inbound-agent:${BASE_TAG}
 USER root
 
 COPY start-agent.sh /usr/local/bin/start.sh
+RUN chmod 755 /usr/local/bin/start.sh
 ENTRYPOINT [ "/usr/local/bin/start.sh" ]
 
 RUN apt-get update && apt-get install -y \

--- a/start-agent.sh
+++ b/start-agent.sh
@@ -18,5 +18,4 @@ if [ $(id -u jenkins) -ne $UID ]; then
   usermod -u $UID jenkins
 fi
 
-# 使用传入的参数列表启动 Jenkins agent
-exec /usr/local/bin/jenkins-agent "$@"
+/usr/local/bin/jenkins-agent "$@"

--- a/start-agent.sh
+++ b/start-agent.sh
@@ -23,4 +23,5 @@ if [ $(id -u jenkins) -ne $UID ]; then
 fi
 
 echo "Starting agent..."
+echo "Arguments: $@"
 su jenkins -m -s /bin/bash -c "/usr/local/bin/jenkins-agent $@"

--- a/start-agent.sh
+++ b/start-agent.sh
@@ -1,0 +1,22 @@
+if [ $(whoami) != "jenkins" ] || [ $(id -u) == "0" ]; then
+  echo "This script must be run as jenkins"
+  exit 1
+fi
+
+if [ -z "$GID" ]; then
+  echo "GID is not set"
+  exit 1
+fi
+if [ -z "$UID" ]; then
+  echo "UID is not set"
+  exit 1
+fi
+if ! grep -q docker /etc/group; then
+  groupadd -g $GID docker && usermod -aG docker jenkins
+fi
+if [ $(id -u jenkins) -ne $UID ]; then
+  usermod -u $UID jenkins
+fi
+
+# 使用传入的参数列表启动 Jenkins agent
+exec /usr/local/bin/jenkins-agent "$@"

--- a/start-agent.sh
+++ b/start-agent.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 if [ $(whoami) != "jenkins" ] || [ $(id -u) == "0" ]; then
   echo "This script must be run as jenkins"
   exit 1

--- a/start-agent.sh
+++ b/start-agent.sh
@@ -23,5 +23,4 @@ if [ $(id -u jenkins) -ne $UID ]; then
 fi
 
 echo "Starting agent..."
-echo "Arguments: $@"
 runuser -u jenkins -m -g docker -- /bin/bash /usr/local/bin/jenkins-agent $@

--- a/start-agent.sh
+++ b/start-agent.sh
@@ -24,4 +24,4 @@ fi
 
 echo "Starting agent..."
 echo "Arguments: $@"
-su jenkins -m -c "/bin/bash /usr/local/bin/jenkins-agent $@"
+runuser -u jenkins -m -g docker -- /bin/bash /usr/local/bin/jenkins-agent $@

--- a/start-agent.sh
+++ b/start-agent.sh
@@ -23,4 +23,4 @@ if [ $(id -u jenkins) -ne $UID ]; then
 fi
 
 echo "Starting agent..."
-su - jenkins -c "/usr/local/bin/jenkins-agent $@"
+su jenkins -m -c "/usr/local/bin/jenkins-agent $@"

--- a/start-agent.sh
+++ b/start-agent.sh
@@ -15,9 +15,11 @@ if [ -z "$UID" ]; then
 fi
 if ! grep -q docker /etc/group; then
   groupadd -g $GID docker && usermod -aG docker jenkins
+  echo "Added docker group"
 fi
 if [ $(id -u jenkins) -ne $UID ]; then
   usermod -u $UID jenkins
+  echo "Changed jenkins UID"
 fi
 
-/usr/local/bin/jenkins-agent "$@"
+su - jenkins -c "/usr/local/bin/jenkins-agent $@"

--- a/start-agent.sh
+++ b/start-agent.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
-if [ $(whoami) != "jenkins" ] || [ $(id -u) == "0" ]; then
-  echo "This script must be run as jenkins"
+if [ $(id -u) != "0" ]; then
+  echo "This script must be run as root"
   exit 1
 fi
 
@@ -22,4 +22,5 @@ if [ $(id -u jenkins) -ne $UID ]; then
   echo "Changed jenkins UID"
 fi
 
+echo "Starting agent..."
 su - jenkins -c "/usr/local/bin/jenkins-agent $@"

--- a/start-agent.sh
+++ b/start-agent.sh
@@ -24,4 +24,4 @@ fi
 
 echo "Starting agent..."
 echo "Arguments: $@"
-su jenkins -m -s /bin/bash -c "/usr/local/bin/jenkins-agent $@"
+su jenkins -m -c "/bin/bash /usr/local/bin/jenkins-agent $@"

--- a/start-agent.sh
+++ b/start-agent.sh
@@ -23,4 +23,4 @@ if [ $(id -u jenkins) -ne $UID ]; then
 fi
 
 echo "Starting agent..."
-su jenkins -m -c "/usr/local/bin/jenkins-agent $@"
+su jenkins -m -s /bin/bash -c "/usr/local/bin/jenkins-agent $@"


### PR DESCRIPTION
由于容器内的 docker 组 id，以及 jenkins 用户的 id 跟宿主机的不一样，导致 docker.sock 权限无法应用，该补丁已修复这个问题。